### PR TITLE
Require minimum `1.3` terraform version

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -20,16 +20,17 @@ jobs:
 
       - name: Create GitHub release
         run: |
-          release_tag="v$(yq '.version' ".github/release.yml")"
+          release_tag="v$(yq '.module_version' "./release-version.yaml")"
+          release_notes="$(yq '.release_notes' "./release-version.yaml")"
 
           echo "Check if the release tag: $release_tag already exists ...."
 
           ## using test case and substituion because git tag command always returns 0 exit code.
           if ! [[ "$(git tag --list "$release_tag")" ]] ; then
             echo "Git Tag: $release_tag does not exists, tag and create a new release"
-            gh release create "$release_tag" --title  "$release_tag" --draft --generate-notes --latest --repo "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+            gh release create "$release_tag" --title  "$release_tag" --draft --generate-notes --latest --repo "${{ github.repository_owner }}/${{ github.event.repository.name }}" --notes "$release_notes"
           else
-            echo "$release_tag already exists, Update the release version in .github/release.yml"
+            echo "$release_tag already exists, Update the module_version in release-version.yaml"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Examples are availabe in `examples` directory.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.55 |
 
 ## Providers

--- a/release-version.yaml
+++ b/release-version.yaml
@@ -1,6 +1,6 @@
 ## Update this file for a new release version.
 
-module_version: "1.7.0"
+module_version: "2.0.0"
 release_notes: |
   Please read the release notes for this release.
 

--- a/release-version.yaml
+++ b/release-version.yaml
@@ -1,0 +1,9 @@
+## Update this file for a new release version.
+
+module_version: "1.7.0"
+release_notes: |
+  Please read the release notes for this release.
+
+    ## What's Changed
+    ### 💡 Other Changes 💡
+    - Automated release workflow.

--- a/versions.tf
+++ b/versions.tf
@@ -5,4 +5,5 @@ terraform {
       version = "~> 3.55"
     }
   }
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
 Introduced minimum terraform version constraint to support the optional types in variables. 

Requires terraform version `>= 1.3` 

refer https://www.hashicorp.com/blog/terraform-1-3-improves-extensibility-and-maintainability-of-terraform-modules 


Auto create release workflow is also added.