### PR TITLE
GH Actions:  Automated release workflow on push to main

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - '**/*.tf' ## trigger release if any terraform file changes.
+      - '**/*.tf'      ## trigger release if any terraform file changes.
       - 'scripts/*.sh' ## trigger release if any involved script has been modified.
       - '.github/workflows/publish-release.yaml'
 
@@ -32,7 +32,7 @@ jobs:
           ## using test case and substituion because git tag command always returns 0 exit code.
           if ! [[ "$(git tag --list "$release_tag")" ]] ; then
             echo "Git Tag: $release_tag does not exists, tag and create a new release"
-            gh release create "$release_tag" --title  "$release_tag" --draft --generate-notes --latest --repo "${{ github.repository_owner }}/${{ github.event.repository.name }}" --notes "$release_notes"
+            gh release create "$release_tag" --title  "$release_tag" --generate-notes --latest --repo "${{ github.repository_owner }}/${{ github.event.repository.name }}" --notes "$release_notes"
           else
             echo "$release_tag already exists, Update the module_version in release-version.yaml"
           fi

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -1,7 +1,14 @@
 name: Validate Pull Request
 on:
   pull_request:
-
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+      - reopened
+      - ready_for_review
 
 jobs:
   validate:


### PR DESCRIPTION
- `.github/workflows/publish-release.yaml`  is adjusted to create releases on every push to the main branch ( only for the respected paths configured ). 

- The release tag will be created from the `module_version` section of the `release-version.yaml` file.
- [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) are supported and Custom Release notes can be also added if required using `release_notes` section of the `release-version.yaml` file.
- fix triggers for the validate check workflow, trigger on relabeling/labeling.